### PR TITLE
Fixed little error when deleting policies with policy emitter objects

### DIFF
--- a/gecoscc/tasks.py
+++ b/gecoscc/tasks.py
@@ -174,7 +174,10 @@ class ChefTask(Task):
         elif rule_type == 'policies':
             policy_id = unicode(policy['_id'])
             if policy.get('is_emitter_policy', False):
-                object_related_id_list = obj[rule_type][policy_id]['object_related_list']
+                if not obj.get(rule_type, None):
+                    object_related_id_list = []
+                else:
+                    object_related_id_list = obj[rule_type][policy_id]['object_related_list']
                 object_related_list = []
                 for object_related_id in object_related_id_list:
                     if policy['slug'] == SOFTWARE_PROFILE_SLUG:


### PR DESCRIPTION
When we deleted objects with related policies within the same node, and those policies were related with policy emitter objects (printers, repositories, software profile and shared folders), an error was produced.