### PR TITLE
Changes to use Chef 12 server instead of Chef 11

### DIFF
--- a/config-templates/development.ini
+++ b/config-templates/development.ini
@@ -26,7 +26,6 @@ session.cookie_on_exception = true
 
 # Chef version number (in X.Y.Z format)
 chef.version = 12.0.0
-chef.chef_server_ctl_path = /opt/opscode/bin/chef-server-ctl
 chef.url = https://localhost/chef/api/
 chef.cookbook_name = gecos_ws_mgmt
 chef.seconds_sleep_is_busy = 5

--- a/config-templates/development.ini
+++ b/config-templates/development.ini
@@ -24,10 +24,14 @@ session.key = session
 session.secret = 12341234
 session.cookie_on_exception = true
 
+# Chef version number (in X.Y.Z format)
+chef.version = 12.0.0
+chef.chef_server_ctl_path = /opt/opscode/bin/chef-server-ctl
 chef.url = https://localhost/chef/api/
 chef.cookbook_name = gecos_ws_mgmt
 chef.seconds_sleep_is_busy = 5
 chef.seconds_block_is_busy = 3600
+
 # smart_lock_sleep_factor is use to avoid concurrency problem
 # We use this parameter to sleep the process between GET and POST request.
 # It's a temporary solution

--- a/gecoscc/commands/create_chef_administrator.py
+++ b/gecoscc/commands/create_chef_administrator.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
     def command(self):
         api = _get_chef_api(self.settings.get('chef.url'),
                             toChefUsername(self.options.chef_username),
-                            self.options.chef_pem)
+                            self.options.chef_pem, self.settings.get('chef.version'))
         try:
             api['/users/%s' % toChefUsername(self.options.username)]
             print "The username %s already exists in the chef sever" % toChefUsername(self.options.username)
@@ -120,7 +120,7 @@ class Command(BaseCommand):
         chef_password = self.create_password("Insert the chef password, the spaces will be stripped",
                                              "The generated password to chef server is: {0}")
         try:
-            create_chef_admin_user(api, self.settings, toChefUsername(self.options.username), chef_password)
+            create_chef_admin_user(api, self.settings, toChefUsername(self.options.username), chef_password, self.options.email)
         except ChefServerError, e:
             print "User not created in chef, error was: %s" % e
             sys.exit(1)

--- a/gecoscc/commands/import_chef_nodes.py
+++ b/gecoscc/commands/import_chef_nodes.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
     def command(self):
         api = _get_chef_api(self.settings.get('chef.url'),
                             toChefUsername(self.options.chef_username),
-                            self.options.chef_pem)
+                            self.options.chef_pem, self.settings.get('chef.version'))
         ou_name = 'ou_0'
         ou = self.create_root_ou(ou_name)
         for node_id in ChefNode.list():

--- a/gecoscc/commands/import_policies.py
+++ b/gecoscc/commands/import_policies.py
@@ -162,7 +162,7 @@ class Command(BaseCommand):
     def command(self):
         api = _get_chef_api(self.settings.get('chef.url'),
                             toChefUsername(self.options.chef_username),
-                            self.options.chef_pem)
+                            self.options.chef_pem, self.settings.get('chef.version'))
         cookbook_name = self.settings['chef.cookbook_name']
 
         cookbook = get_cookbook(api, cookbook_name)

--- a/gecoscc/commands/migrate_to_chef12.py
+++ b/gecoscc/commands/migrate_to_chef12.py
@@ -1,0 +1,260 @@
+#
+# Copyright 2013, Junta de Andalucia
+# http://www.juntadeandalucia.es/
+#
+# Authors:
+#   Abraham Macias <amacias@solutia-it.es>
+#
+# All rights reserved - EUPL License V 1.1
+# https://joinup.ec.europa.eu/software/page/eupl/licence-eupl
+#
+
+import os
+import sys
+import string
+import random
+import subprocess
+
+from chef.exceptions import ChefServerNotFoundError, ChefServerError
+from getpass import getpass
+from optparse import make_option
+
+from gecoscc.management import BaseCommand
+from gecoscc.userdb import UserAlreadyExists
+from gecoscc.utils import _get_chef_api, create_chef_admin_user, password_generator, toChefUsername
+
+
+def password_generator(size=8, chars=string.ascii_lowercase + string.digits):
+    return ''.join(random.choice(chars) for x in range(size))
+
+class Command(BaseCommand):
+    description = """
+       Check the administrators, users, clients and the ACL permissions of Chef and GECOS CC mongo database.
+    """
+
+    usage = "usage: %prog config_uri migrate_to_chef12 --administrator user --key file.pem"
+
+    option_list = [
+        make_option(
+            '-a', '--administrator',
+            dest='chef_username',
+            action='store',
+            help='An existing chef super administrator username (like "pivotal" user)'
+        ),
+        make_option(
+            '-k', '--key',
+            dest='chef_pem',
+            action='store',
+            help='The pem file that contains the chef administrator private key'
+        ),
+    ]
+
+    required_options = (
+        'chef_username',
+        'chef_pem',
+    )
+    
+    
+    def isChefUserSuperadmin(self, username):
+        found = False
+        cmd = '%s list-server-admins'%(self.settings.get('chef.chef_server_ctl_path'))
+        p = subprocess.Popen(cmd, shell=True, 
+                             stdout=subprocess.PIPE, 
+                             stderr=subprocess.STDOUT)
+
+        # Read the process output with a timeout
+        stdout = p.stdout.read()
+        for line in stdout.split('\n'):
+            if line.strip() == username:
+                found = True
+        
+        retval = p.wait()      
+        
+        return found
+    
+
+    def command(self):
+        api = _get_chef_api(self.settings.get('chef.url'),
+                            toChefUsername(self.options.chef_username),
+                            self.options.chef_pem, self.settings.get('chef.version'))
+                            
+        if self.settings.get('chef.chef_server_ctl_path') is None:
+            print "ERROR: plase configure 'chef.chef_server_ctl_path' in gecoscc.ini file!"
+            return
+                            
+                  
+        print '============ CHECKING ADMINISTRATOR USERS ============='                  
+        # Check if all the GECOS CC administrators
+        # are properly created in Chef 12
+        admin_users = self.pyramid.userdb.list_users()
+        for admin_user in admin_users:
+            print 'Checking admin user: %s'%(admin_user['username'])
+            
+            # The email must be unique
+            users_with_email = self.pyramid.userdb.list_users({'email': admin_user['email']})
+            if users_with_email.count() > 1:
+                print "ERROR: more than one user with this email: %s"%(admin_user['email'])
+
+            # Get the Chef user
+            chef_user = None
+            try:
+                chef_user = api['/users/%s' % toChefUsername(admin_user['username'])]
+            except ChefServerNotFoundError:
+                pass            
+                            
+            if chef_user is None:
+                # No chef user found
+                print "WARNING: No Chef user found. We will try to create it!"
+                
+                chef_password = password_generator()
+                try:
+                    create_chef_admin_user(api, self.settings, toChefUsername(admin_user['username']), chef_password, admin_user['email'])
+                except ChefServerError, e:
+                    print "User not created in chef, error was: %s" % e
+                    sys.exit(1)                
+                            
+                chef_user = api['/users/%s' % toChefUsername(admin_user['username'])]
+
+            # Check the email of the chef user
+            if chef_user['email'] != admin_user['email']:
+                print "WARNING: The chef user email and the GECOS CC user email doesn't match!"
+                print "Try to change the chef user email!"
+                chef_user['email'] = admin_user['email']
+                api.api_request('PUT', '/users/%s'%(toChefUsername(admin_user['username'])), data=chef_user)                
+            
+            # Check if the administrator is a superuser
+            isChefSuperuser = self.isChefUserSuperadmin(toChefUsername(admin_user['username']))
+            if admin_user['is_superuser'] and not isChefSuperuser:
+                print "WARNING: GECOS superuser is not a Chef superuser. We will try to change this!"
+                
+                # Include the user in the "server-admins" group
+                cmd = [self.settings.get('chef.chef_server_ctl_path'), 'grant-server-admin-permissions', toChefUsername(admin_user['username'])]
+                if subprocess.call(cmd) != 0:
+                    print 'ERROR: error adding the administrator to "server-admins" chef group'
+              
+            if not admin_user['is_superuser'] and isChefSuperuser:
+                print "WARNING: Chef superuser is not a GECOS superuser. We will try to change this!"
+                
+                # Remove the user from the "server-admins" group
+                cmd = [self.settings.get('chef.chef_server_ctl_path'), 'remove-server-admin-permissions', toChefUsername(admin_user['username'])]
+                if subprocess.call(cmd) != 0:
+                    print 'ERROR: error removing the administrator to "server-admins" chef group'
+            
+            
+            # Check if the administrator belongs to the "admins" group in the "default" organization
+            admins_group = None
+            try:
+                admins_group = api['/organizations/default/groups/admins']
+            except ChefServerNotFoundError:
+                pass             
+                
+            if not toChefUsername(admin_user['username']) in admins_group['users']:
+                print "WARNING: GECOS administrator is not a chef administrator for the default organization. We will try to change this!"
+                
+                # Check if exists an association request for this user
+                assoc_requests = None
+                try:
+                    assoc_requests = api['/organizations/default/association_requests']
+                except ChefServerNotFoundError:
+                    pass                    
+                
+                association_id = None
+                for req in assoc_requests:
+                    if req["username"] == toChefUsername(admin_user['username']):
+                        association_id = req["id"]
+                
+                if association_id is None:
+                    # Set an association request for the user in that organization
+                    try:
+                        data = {"user": toChefUsername(admin_user['username'])}
+                        response = api.api_request('POST', '/organizations/default/association_requests', data=data) 
+                        association_id = response["uri"].split("/")[-1]
+                    except ChefServerError:
+                        # Association already exists?
+                        pass                    
+
+                if association_id is not None:
+                    # Accept the association request
+                    api.api_request('PUT', '/users/%s/association_requests/%s'%(toChefUsername(admin_user['username']), association_id),  data={ "response": 'accept' }) 
+
+                # Add the user to the group
+                admins_group['users'].append(toChefUsername(admin_user['username']))
+                api.api_request('PUT', '/organizations/default/groups/admins', data={ "groupname": admins_group["groupname"], 
+                    "actors": {
+                        "users": admins_group['users'],
+                        "groups": admins_group["groups"]
+                    }
+                    }) 
+            
+        
+        # Check if all the clients have permissions over the computer node with the same name (if exists)
+        print '============ CHECKING COMPUTERS ============='                  
+        computers = self.db.nodes.find_one({"type" : "computer"})
+        if not isinstance(computers, list):
+            computers = [computers]
+        
+        for computer in computers:
+            print 'Checking computer: %s'%(computer['name'])
+            
+            # Check if the chef node exists
+            chef_node = None
+            try:
+                chef_node = api['/organizations/default/nodes/%s'%(computer["node_chef_id"])]
+            except ChefServerNotFoundError:
+                pass              
+            
+            if chef_node is None:
+                print "ERROR: There is no chef node!"
+                continue
+                
+            # Check if the chef client exists
+            chef_client = None
+            try:
+                chef_client = api['/organizations/default/clients/%s'%(computer["node_chef_id"])]
+            except ChefServerNotFoundError:
+                pass              
+            
+            if chef_client is None:
+                print "ERROR: There is no chef client!"
+                continue
+                
+            # Check the ACL for the node
+            acl = None
+            try:
+                acl = api['/organizations/default/nodes/%s/_acl'%(computer["node_chef_id"])]
+            except ChefServerNotFoundError:
+                pass              
+            
+            if acl is None:
+                print "ERROR: Can't find the node ACL!"
+                continue
+
+            if not computer["node_chef_id"] in acl['create']['actors']:
+                print "INFO: Fix create permission"
+                acl['create']['actors'].append(computer["node_chef_id"])
+                api.api_request('PUT', '/organizations/default/nodes/%s/_acl/create'%(computer["node_chef_id"]), data={'create': acl['create']})                 
+                
+            if not computer["node_chef_id"] in acl['read']['actors']:
+                print "INFO: Fix read permission"
+                acl['read']['actors'].append(computer["node_chef_id"])
+                api.api_request('PUT', '/organizations/default/nodes/%s/_acl/read'%(computer["node_chef_id"]), data={'read': acl['read']})                 
+
+            if not computer["node_chef_id"] in acl['update']['actors']:
+                print "INFO: Fix update permission"
+                acl['update']['actors'].append(computer["node_chef_id"])
+                api.api_request('PUT', '/organizations/default/nodes/%s/_acl/update'%(computer["node_chef_id"]), data={'update': acl['update']})                 
+                
+            if not computer["node_chef_id"] in acl['grant']['actors']:
+                print "INFO: Fix grant permission"
+                acl['grant']['actors'].append(computer["node_chef_id"])
+                api.api_request('PUT', '/organizations/default/nodes/%s/_acl/grant'%(computer["node_chef_id"]), data={'grant': acl['grant']})                 
+
+            if not computer["node_chef_id"] in acl['delete']['actors']:
+                print "INFO: Fix delete permission"
+                acl['delete']['actors'].append(computer["node_chef_id"])
+                api.api_request('PUT', '/organizations/default/nodes/%s/_acl/delete'%(computer["node_chef_id"]), data={'delete': acl['delete']})                 
+
+                
+            
+                
+        

--- a/gecoscc/forms.py
+++ b/gecoscc/forms.py
@@ -13,6 +13,7 @@ import os
 
 import colander
 import deform
+import logging
 
 from pkg_resources import resource_filename
 
@@ -30,6 +31,7 @@ default_dir = resource_filename('deform', 'templates/')
 gecoscc_dir = resource_filename('gecoscc', 'templates/deform/')
 gecos_renderer = ZPTRendererFactory((gecoscc_dir, default_dir))
 
+logger = logging.getLogger(__name__)
 
 class GecosButton(deform.Button):
 
@@ -102,9 +104,10 @@ class AdminUserAddForm(BaseAdminUserForm):
         admin_user['plain_password'] = self.cstruct['password']
         settings = get_current_registry().settings
         user = self.request.user
+        
         api = get_chef_api(settings, user)
         try:
-            create_chef_admin_user(api, settings, admin_user['username'])
+            create_chef_admin_user(api, settings, admin_user['username'], None, admin_user['email'])
             self.created_msg(_('User created successfully'))
             return True
         except ChefServerError as e:

--- a/gecoscc/templates/admins/edit.jinja2
+++ b/gecoscc/templates/admins/edit.jinja2
@@ -27,21 +27,6 @@
                 <a href="{{ request.route_url('admins_set_variables', username=username) }}" class="btn btn-primary pull-right"><span class="fa"></span> {{ gettext('Set variables') }}</a>
                 {% if request.user.get('is_superuser') %}
                     <a href="{{ request.route_url('admins_ou_manage', username=username) }}" class="btn btn-primary pull-right"><span class="fa"></span> {{ gettext('Set Organitation Unit managed by this user') }}</a>
-                    
-                    {% if registry.settings.get('chef.chef_server_ctl_path') is not none %}
-                    <form method="POST" accept-charset="utf-8" role="form" action="{{ request.route_url('admins_superuser', username=username) }}">
-                        {% if not instance.get('is_superuser') %}
-                            <button id="deform_submit" name="_superuser" type="submit" class="btn btn-primary pull-right" value="_submit">
-                                {{ gettext('Set like superuser') }}
-                            </button>
-                        {% else %}
-                            <button id="deform_submit" name="_no_superuser" type="submit" class="btn btn-primary pull-right" value="_submit">
-                                {{ gettext('Remove like superuser') }}
-                            </button>
-                        {% endif %}
-                    </form>
-                    {% endif %}
-                    
                 {% endif %}
             </div>
         </div>

--- a/gecoscc/templates/admins/edit.jinja2
+++ b/gecoscc/templates/admins/edit.jinja2
@@ -27,6 +27,8 @@
                 <a href="{{ request.route_url('admins_set_variables', username=username) }}" class="btn btn-primary pull-right"><span class="fa"></span> {{ gettext('Set variables') }}</a>
                 {% if request.user.get('is_superuser') %}
                     <a href="{{ request.route_url('admins_ou_manage', username=username) }}" class="btn btn-primary pull-right"><span class="fa"></span> {{ gettext('Set Organitation Unit managed by this user') }}</a>
+                    
+                    {% if registry.settings.get('chef.chef_server_ctl_path') is not none %}
                     <form method="POST" accept-charset="utf-8" role="form" action="{{ request.route_url('admins_superuser', username=username) }}">
                         {% if not instance.get('is_superuser') %}
                             <button id="deform_submit" name="_superuser" type="submit" class="btn btn-primary pull-right" value="_submit">
@@ -38,6 +40,8 @@
                             </button>
                         {% endif %}
                     </form>
+                    {% endif %}
+                    
                 {% endif %}
             </div>
         </div>

--- a/gecoscc/tests.py
+++ b/gecoscc/tests.py
@@ -52,7 +52,7 @@ CHEF_URL = 'https://CHEF_URL/'
 CHEF_NODE_ID = '36e13492663860e631f53a00afcdd92d'
 
 
-def create_chef_admin_user_mock(api, settings, username, password=None):
+def create_chef_admin_user_mock(api, settings, username, password=None, email='nobody@nobody.es'):
     pass
 
 

--- a/gecoscc/utils.py
+++ b/gecoscc/utils.py
@@ -189,8 +189,6 @@ def create_chef_admin_user(api, settings, usrname, password=None, email='nobody@
     if password is None:
         password = password_generator()
         
-    logger.info('Create Chef admin user: %s'%(username))
-        
     if api.version_parsed >= pkg_resources.parse_version("12.0.0"):
         # Chef 12 user data
         data = {'name': username, 'password': password, 'admin': True, 'display_name': username, 'email': email}
@@ -198,16 +196,14 @@ def create_chef_admin_user(api, settings, usrname, password=None, email='nobody@
         # Chef 11 user data
         data = {'name': username, 'password': password, 'admin': True}
         
-    logger.info('data %s'%(json.dumps(data)))
     chef_user = api.api_request('POST', '/users', data=data)
-    logger.info('User created')
+
     user_private_key = chef_user.get('private_key', None)
     if user_private_key:
         save_pem_for_username(settings, username, 'chef_user.pem', user_private_key)
-    logger.info('Creating client')
+
     chef_client = Client.create(name=username, api=api, admin=True)
     client_private_key = getattr(chef_client, 'private_key', None)
-    logger.info('client created')
     if client_private_key:
         save_pem_for_username(settings, username, 'chef_client.pem', client_private_key)
 

--- a/gecoscc/utils.py
+++ b/gecoscc/utils.py
@@ -17,6 +17,8 @@ import random
 import string
 import time
 import re
+import pkg_resources
+import logging
 
 from bson import ObjectId, json_util
 from copy import deepcopy, copy
@@ -35,6 +37,7 @@ USER_MGMT = 'users_mgmt'
 SOURCE_DEFAULT = MASTER_DEFAULT = 'gecos'
 USE_NODE = 'use_node'
 
+logger = logging.getLogger(__name__)
 
 def get_policy_emiter_id(collection, obj):
     '''
@@ -167,34 +170,44 @@ def password_generator(size=8, chars=string.ascii_lowercase + string.digits):
 def get_chef_api(settings, user):
     username = toChefUsername(user['username'])
     chef_url = settings.get('chef.url')
-    chef_client_pem = get_pem_path_for_username(settings, username, 'chef_client.pem')
     chef_user_pem = get_pem_path_for_username(settings, username, 'chef_user.pem')
-    if os.path.exists(chef_client_pem):
-        chef_pem = chef_client_pem
-    else:
-        chef_pem = chef_user_pem
-    api = _get_chef_api(chef_url, username, chef_pem)
+    api = _get_chef_api(chef_url, username, chef_user_pem, settings.get('chef.version'))
+        
     return api
 
 
-def _get_chef_api(chef_url, username, chef_pem):
+def _get_chef_api(chef_url, username, chef_pem, chef_version = '11.0.0'):
     if not os.path.exists(chef_pem):
         raise ChefError('User has no pem to access chef server')
-    api = ChefAPI(chef_url, chef_pem, username)
+    api = ChefAPI(chef_url, chef_pem, username, chef_version)
+    
     return api
 
 
-def create_chef_admin_user(api, settings, usrname, password=None):
+def create_chef_admin_user(api, settings, usrname, password=None, email='nobody@nobody.es'):
     username = toChefUsername(usrname)
     if password is None:
         password = password_generator()
-    data = {'name': username, 'password': password, 'admin': True}
+        
+    logger.info('Create Chef admin user: %s'%(username))
+        
+    if api.version_parsed >= pkg_resources.parse_version("12.0.0"):
+        # Chef 12 user data
+        data = {'name': username, 'password': password, 'admin': True, 'display_name': username, 'email': email}
+    else:
+        # Chef 11 user data
+        data = {'name': username, 'password': password, 'admin': True}
+        
+    logger.info('data %s'%(json.dumps(data)))
     chef_user = api.api_request('POST', '/users', data=data)
+    logger.info('User created')
     user_private_key = chef_user.get('private_key', None)
     if user_private_key:
         save_pem_for_username(settings, username, 'chef_user.pem', user_private_key)
+    logger.info('Creating client')
     chef_client = Client.create(name=username, api=api, admin=True)
     client_private_key = getattr(chef_client, 'private_key', None)
+    logger.info('client created')
     if client_private_key:
         save_pem_for_username(settings, username, 'chef_client.pem', client_private_key)
 


### PR DESCRIPTION
Because Chef 12 has multitenancy based on organizations, to use Chef 12, the GECOS structure is stored in the "default" organization.
Also, the clients with "admin" permissions dissapear, and the users can't create nor delete other users if such permissions aren't granted by using the "chef-server-ctl grant-server-admin-permissions" command.

This pull request contains the minimum changes to use GECOS CC with Chef 12 server.

Also, a "migrate_to_chef12" command is added. This command checks the user permissions and the computer ACLs and fix them is necessary. This script may be launched after migrating from Chef 11 to Chef 12.