### PR TITLE
Added default session timeout setting it to 20 minutes.

### DIFF
--- a/config-templates/development.ini
+++ b/config-templates/development.ini
@@ -19,6 +19,16 @@ mongo_uri = mongodb://localhost:27017/gecoscc
 redis_uri = redis://localhost:6379/4
 #redis_uri = redis://:password@localhost:6379/4
 
+# Pyramid - Beaker sessions configuration
+# See: http://beaker.readthedocs.io/en/latest/configuration.html#session-options
+## Session expires on closing the browser
+beaker.session.cookie_expires = true
+## Session expires after 20 minutes without accesing (20 minutes = 1200 seconds)
+beaker.session.timeout=1200
+beaker.session.save_accessed_time=true
+
+
+
 session.type = file
 session.data_dir = %(here)s/sessions/data
 session.lock_dir = %(here)s/sessions/lock


### PR DESCRIPTION
Added configuration for the 'pyramid_beaker' module to set a session timeout of 20 minutes and to destroy the session when the user closes the browser.

More info about Beaker configuration in:
 http://beaker.readthedocs.io/en/latest/configuration.html#session-options

