### PR TITLE
Scripts to upgrade to Chef 12

### DIFF
--- a/gecoscc/commands/check_node_policies.py
+++ b/gecoscc/commands/check_node_policies.py
@@ -86,9 +86,16 @@ class Command(BaseCommand):
         logger.info('Getting all the policies structures from database...')
         dbpolicies = self.db.policies.find()
         self.policiesdata = {}
+        self.slug_check = {}
         for policy in dbpolicies:
             logger.debug('Addig to dictionary: %s => %s'%(policy['_id'], json.dumps(policy['schema'])))
             self.policiesdata[str(policy['_id'])] = policy
+            if policy['slug'] in self.slug_check:
+                logger.error("There are more than one policy with '%s' slug!"%(policy['slug']))
+            else:
+                self.slug_check[policy['slug']] = policy
+                
+                
         
         logger.info('Checking tree...')
         # Look for the root of the nodes tree

--- a/gecoscc/commands/check_node_policies.py
+++ b/gecoscc/commands/check_node_policies.py
@@ -1,0 +1,286 @@
+#
+# Copyright 2017, Junta de Andalucia
+# http://www.juntadeandalucia.es/
+#
+# Authors:
+#   Abraham Macias <amacias@solutia-it.es>
+#
+# All rights reserved - EUPL License V 1.1
+# https://joinup.ec.europa.eu/software/page/eupl/licence-eupl
+#
+
+import os
+import sys
+import string
+import random
+import subprocess
+import json
+
+from chef.exceptions import ChefServerNotFoundError, ChefServerError
+from getpass import getpass
+from optparse import make_option
+
+from gecoscc.management import BaseCommand
+from gecoscc.userdb import UserAlreadyExists
+from gecoscc.utils import _get_chef_api, create_chef_admin_user, password_generator, toChefUsername
+
+
+def password_generator(size=8, chars=string.ascii_lowercase + string.digits):
+    return ''.join(random.choice(chars) for x in range(size))
+
+import logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)    
+    
+class Command(BaseCommand):
+    description = """
+       Check the policies data for all the workstations in the database. 
+       This script must be executed on major policies updates when the changes in the policies structure may
+       cause problems if the Chef nodes aren't properly updated.
+       
+       So, the curse of action is:
+       1) Import the new policies with the knife command
+       2) Run the "import_policies" command.
+       3) Run this "check_node_policies" command.
+    """
+
+    usage = "usage: %prog config_uri check_node_policies --administrator user --key file.pem"
+
+    option_list = [
+        make_option(
+            '-a', '--administrator',
+            dest='chef_username',
+            action='store',
+            help='An existing chef super administrator username (like "pivotal" user)'
+        ),
+        make_option(
+            '-k', '--key',
+            dest='chef_pem',
+            action='store',
+            help='The pem file that contains the chef administrator private key'
+        ),
+    ]
+
+    required_options = (
+        'chef_username',
+        'chef_pem',
+    )
+    
+    
+    def command(self):
+        # Initialization
+        self.api = _get_chef_api(self.settings.get('chef.url'),
+                            toChefUsername(self.options.chef_username),
+                            self.options.chef_pem, self.settings.get('chef.version'))
+
+        self.db = self.pyramid.db
+        
+        # Get all the policies structures
+        logger.info('Getting all the policies structures from database...')
+        dbpolicies = self.db.policies.find()
+        self.policiesdata = {}
+        for policy in dbpolicies:
+            logger.debug('Addig to dictionary: %s => %s'%(policy['_id'], json.dumps(policy['schema'])))
+            self.policiesdata[str(policy['_id'])] = policy
+        
+        logger.info('Checking tree...')
+        # Look for the root of the nodes tree
+        root_nodes = self.db.nodes.find({"path" : "root"})    
+        for root in root_nodes:        
+            self.check_node_and_subnodes(root)
+        
+        
+        logger.info('END ;)')
+        
+    def check_node_and_subnodes(self, node):
+        '''
+        Check the policies applied to a node and its subnodes
+        '''        
+        self.check_node(node)
+        
+        if node['type'] == 'ou':
+            subnodes = self.db.nodes.find({"path" : "%s,%s"%(node['path'], node['_id'])}) 
+            for subnode in subnodes:
+                self.check_node_and_subnodes(subnode)
+        
+        
+    def check_node(self, node):
+        '''
+        Check the policies applied to a node
+        '''        
+        logger.info('Checking node: %s type:%s path: %s'%(node['name'], node['type'], node['path']))
+        
+        if 'policies' in node:
+            # Check the policies data
+            for policy in node['policies']:
+                logger.debug('Checking policy with ID: %s'%(policy))
+                if not str(policy) in self.policiesdata:
+                    logger.error("Can't find %s policy data en the database!"%(policy))
+                else:
+                    policydata = self.policiesdata[str(policy)]
+                    nodedata = node['policies'][str(policy)]
+                    
+                    # Emiters policies have a "name" field in the data
+                    # Non emiters policies have a "title" field in the data
+                    namefield = 'name'
+                    if not (namefield in policydata):
+                        namefield = 'title'
+                    
+                    if not ('name' in policydata):
+                        logger.critical('Policy with ID: %s doesn\'t have a name nor title!'%(str(policy)))
+                        continue;
+                        
+                      
+                    logger.info('Checking policy: %s'%(policydata[namefield]))
+                    logger.debug('Node policy data: %s'%(json.dumps(node['policies'][str(policy)])))
+                    
+                    # Check object
+                    self.check_object_property(policydata['schema'], nodedata, None)
+                            
+        else:
+            logger.debug('No policies in this node.')
+        
+        
+    def check_boolean_property(self, schema, nodedata, property):
+        if schema is None:
+            raise ValueError('Schema is None!')
+            
+        if nodedata is None:
+            raise ValueError('Nodedata is None!')            
+            
+        if schema['type'] != 'boolean':
+            raise ValueError('Schema doesn\'t represent a boolean!')
+            
+        if nodedata not in ['true', 'false', 'True', 'False', True, False]:
+            logger.error('Bad property value: %s (not a boolean) for property %s'%(nodedata, property))
+            
+            
+    def check_number_property(self, schema, nodedata, property):
+        if schema is None:
+            raise ValueError('Schema is None!')
+            
+        if nodedata is None:
+            raise ValueError('Nodedata is None!')            
+            
+        if (schema['type'] != 'number') and (schema['type'] != 'integer'):
+            raise ValueError('Schema doesn\'t represent a number!')
+            
+        if not isinstance( nodedata, ( int, long ) ) and not nodedata.isdigit():
+            logger.error('Bad property value: %s (not a number) for property %s'%(nodedata, property))
+            
+            
+    def check_string_property(self, schema, nodedata, property):
+        if schema is None:
+            raise ValueError('Schema is None!')
+            
+        if nodedata is None:
+            raise ValueError('Nodedata is None!')            
+            
+        if schema['type'] != 'string':
+            raise ValueError('Schema doesn\'t represent a number!')
+            
+        if not isinstance(nodedata, (str, unicode)):
+            logger.error('Bad property value: %s (not a string) for property %s'%(nodedata, property))
+            return
+            
+        if 'enum' in schema:
+            if ( len(schema['enum']) > 0 ) and  not (nodedata in schema['enum']):
+                logger.error('Bad property value: %s (not in enumeration %s) for property %s'%(nodedata, schema['enum'], property))
+                
+            
+    def check_object_property(self, schema, nodedata, propertyname):
+        if schema is None:
+            raise ValueError('Schema is None!')
+            
+        if nodedata is None:
+            raise ValueError('Nodedata is None!')            
+            
+        if schema['type'] != 'object':
+            raise ValueError('Schema doesn\'t represent a object!')
+            
+        # Check required properties
+        if 'required' in schema:
+            for property in schema['required']:
+                name = str(property)
+                if propertyname is not None:
+                    name = "%s.%s"%(propertyname, property)
+                logger.debug('\tChecking required property: %s'%(name))
+                if str(property) in nodedata:
+                    logger.debug('\tRequired property: %s exists in the node data.'%(name))
+                else:
+                    logger.error('\tRequired property: %s doesn\'t exists in the node data!'%(name))
+
+                    
+        # Compare the policy schema and the node data
+        for property in schema['properties'].keys():
+            type = schema['properties'][str(property)]['type']
+            name = str(property)
+            if propertyname is not None:
+                name = "%s.%s"%(propertyname, property)
+            logger.debug('\tChecking property: %s (%s)'%(name, type))
+            if not str(property) in nodedata:
+                logger.debug('\tNon required property missing: %s'%(name))
+                continue;
+            
+            if type == 'array':
+                self.check_array_property(schema['properties'][str(property)], nodedata[str(property)], name)
+                
+            elif type == 'string':
+                self.check_string_property(schema['properties'][str(property)], nodedata[str(property)], name)
+            
+            elif type == 'object':
+                self.check_object_property(schema['properties'][str(property)], nodedata[str(property)], name)
+        
+            elif (type == 'number') or (type == 'integer'):
+                self.check_number_property(schema['properties'][str(property)], nodedata[str(property)], name)
+
+            elif type == 'boolean':
+                self.check_boolean_property(schema['properties'][str(property)], nodedata[str(property)], name)
+
+            else:
+                logger.error('Unknown property type found: %s'%(type))
+            
+            
+
+    def check_array_property(self, schema, nodedata, propertyname):
+        if schema is None:
+            raise ValueError('Schema is None!')
+            
+        if nodedata is None:
+            raise ValueError('Nodedata is None!')            
+            
+        if schema['type'] != 'array':
+            raise ValueError('Schema doesn\'t represent an array!')
+
+        if not isinstance(nodedata, list):
+            logger.error('Bad property value: %s (not an array) for property %s'%(nodedata, propertyname))
+            return
+
+        if 'minItems' in schema:
+            if len(nodedata) < schema['minItems']:
+                logger.error('Bad property value: %s (under min items) for property %s'%(nodedata, propertyname))
+                return
+
+        type = schema['items']['type']
+        count = 0
+        for value in nodedata:
+            name = '%s[%s]'%(propertyname, count)
+            if type == 'array':
+                self.check_array_property(schema['items'], value, name)
+                
+            elif type == 'string':
+                self.check_string_property(schema['items'], value, name)
+            
+            elif type == 'object':
+                self.check_object_property(schema['items'], value, name)
+        
+            elif (type == 'number') or (type == 'integer'):
+                self.check_number_property(schema['items'], value, name)
+
+            elif type == 'boolean':
+                self.check_boolean_property(schema['items'], value, name)
+
+            else:
+                logger.error('Unknown property type found: %s'%(type))
+                
+            count += 1

--- a/gecoscc/commands/check_node_policies.py
+++ b/gecoscc/commands/check_node_policies.py
@@ -242,7 +242,7 @@ class Command(BaseCommand):
                 
             
             # Check members
-            new_id_list = self.check_referenced_nodes(node['members'], ['user', 'computer'], 'members')
+            new_id_list = self.check_referenced_nodes(node['members'], ['user', 'computer', 'group'], 'members')
             difference = set(node['members']).difference(set(new_id_list))
             if len(difference) > 0:
                 logger.info('FIX: remove %s references'%(difference))

--- a/gecoscc/commands/check_node_policies.py
+++ b/gecoscc/commands/check_node_policies.py
@@ -74,7 +74,7 @@ class Command(BaseCommand):
         # Initialization
         self.api = _get_chef_api(self.settings.get('chef.url'),
                             toChefUsername(self.options.chef_username),
-                            self.options.chef_pem, self.settings.get('chef.version'))
+                            self.options.chef_pem, False, self.settings.get('chef.version'))
 
         self.db = self.pyramid.db
         self.referenced_data_type = {}

--- a/gecoscc/commands/check_node_policies.py
+++ b/gecoscc/commands/check_node_policies.py
@@ -215,7 +215,7 @@ class Command(BaseCommand):
                 found = True
                 logger.debug('Referenced node %s for property %s is a %s node'%(id, property, ref_nodes["type"]))
                 if not (ref_nodes["type"] in possible_types):
-                    logger.error('Bad data type in referenced node %s for property %s (%s not in %s)'%(nodedata, property, ref_nodes["type"], possible_types))
+                    logger.error('Bad data type in referenced node %s for property %s (%s not in %s)'%(id, property, ref_nodes["type"], possible_types))
                 
             if not found:
                 logger.error('Can\'t find referenced node %s for property %s'%(id, property))                

--- a/gecoscc/commands/check_node_policies.py
+++ b/gecoscc/commands/check_node_policies.py
@@ -135,7 +135,14 @@ class Command(BaseCommand):
                 found = True
                 
             if not found:
-                logger.error("No computer node for Chef ID: '%s'!"%(node_id))
+                pclabel = "(No OHAI-GECOS data in the node)"
+                computer_node = ChefNode(node_id, self.api)
+                try:
+                    pclabel = "(pclabel = %s)"%( computer_node.attributes.get_dotted('ohai_gecos.pclabel') )
+                except KeyError:
+                    pass
+                        
+                logger.error("No computer node for Chef ID: '%s' %s!"%(node_id, pclabel))
         
         
         logger.info('END ;)')

--- a/gecoscc/commands/check_node_policies.py
+++ b/gecoscc/commands/check_node_policies.py
@@ -141,7 +141,7 @@ class Command(BaseCommand):
         '''
         Check the policies applied to a node
         '''        
-        logger.info('Checking node: %s type:%s path: %s'%(node['name'], node['type'], node['path']))
+        logger.info('Checking node: "%s" type:%s path: %s'%(node['name'], node['type'], node['path']))
         
         # Check policies
         if 'policies' in node:
@@ -165,7 +165,7 @@ class Command(BaseCommand):
                         continue;
                         
                       
-                    logger.info('Checking policy: %s'%(policydata[namefield]))
+                    logger.info('Checking node: "%s" Checking policy: "%s"'%(node['name'], policydata[namefield]))
                     if 'DEPRECATED' in policydata[namefield]:
                         logger.warning('Using deprecated policy: %s'%(policydata[namefield]))
                         

--- a/gecoscc/commands/migrate_to_chef12.py
+++ b/gecoscc/commands/migrate_to_chef12.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
     def command(self):
         api = _get_chef_api(self.settings.get('chef.url'),
                             toChefUsername(self.options.chef_username),
-                            self.options.chef_pem, self.settings.get('chef.version'))
+                            self.options.chef_pem, False, self.settings.get('chef.version'))
                             
         print '============ CHECKING ADMINISTRATOR USERS ============='                  
         # Check if all the GECOS CC administrators
@@ -87,7 +87,8 @@ class Command(BaseCommand):
                 try:
                     create_chef_admin_user(api, self.settings, toChefUsername(admin_user['username']), chef_password, admin_user['email'])
                 except ChefServerError, e:
-                    print "User not created in chef, error was: %s" % e
+                    print "ERROR: User not created in chef, error was: %s" % e
+                    print "(Check /opt/opscode/embedded/service/opscode-erchef/log/requests.log* for more info)"
                     sys.exit(1)                
                             
                 chef_user = api['/users/%s' % toChefUsername(admin_user['username'])]
@@ -147,10 +148,7 @@ class Command(BaseCommand):
         
         # Check if all the clients have permissions over the computer node with the same name (if exists)
         print '============ CHECKING COMPUTERS ============='                  
-        computers = self.db.nodes.find_one({"type" : "computer"})
-        if not isinstance(computers, list):
-            computers = [computers]
-        
+        computers = self.db.nodes.find({"type" : "computer"})
         for computer in computers:
             print 'Checking computer: %s'%(computer['name'])
             


### PR DESCRIPTION
* migrate_to_chef12: Some bugfixes.
* check_node_policies: Script that checks the MongoDB database for problems. Reports all the errors found and fixes relationship problems by deleting the relationship. For example, if a user is supposed to be related with a computer that doesn't exists in the database, that relationship is deleted.

These scripts are used after a migration from Chef 11 to Chef 12 to ensure that the system will work properly.