### PR TITLE
Bugfix global name 'DELETED_POLICY_ACTION' is not defined

### DIFF
--- a/gecoscc/utils.py
+++ b/gecoscc/utils.py
@@ -991,6 +991,7 @@ def _nested_lookup(key, document):
 
 # INI: TRACE INHERITANCE #
 def trace_inheritance(db, action, obj, policy):
+    from gecoscc.tasks import DELETED_POLICY_ACTION
     logger.debug("utils.py ::: Starting trace_inheritance ...")
 
     items = []


### PR DESCRIPTION
Import DELETED_POLICY_ACTION constant from gecoscc.tasks