### PR TITLE
Bugfix get_merge_policies: field_ui callable not generate jobs well.

### DIFF
--- a/gecoscc/tasks.py
+++ b/gecoscc/tasks.py
@@ -582,7 +582,7 @@ class ChefTask(Task):
             self.log("debug","tasks.py ::: get_merge_policies - obj_ui_copy = {0}".format(obj_ui_copy))
 
             objold_ui_field = field_ui(objold_ui_copy, obj=objold_copy, node=node, field_chef=field_chef)
-            obj_ui_field    = field_ui(obj_ui_copy, obj=obj_copy, node=node, field_chef=field_chef)
+            obj_ui_field    = obj_ui.get(field_chef.split('.')[-1])
         else:
             objold_ui_field = objold_ui.get(field_ui, [])
             obj_ui_field = obj_ui.get(field_ui, [])


### PR DESCRIPTION
When field_ui is callable, then obj_ui has already been applied to the particular function. It is not necessary to reapply it or in this case the comparison with objold_ui will always be different,  generating a task of more