### PR TITLE
Bugfix Cookbook Upload: Invalid cross-device link

### DIFF
--- a/gecoscc/forms.py
+++ b/gecoscc/forms.py
@@ -9,7 +9,7 @@
 # https://joinup.ec.europa.eu/software/page/eupl/licence-eupl
 #
 
-import os, errno
+import os, errno, shutil
 import time
 import re
 import glob
@@ -286,7 +286,7 @@ class CookbookUploadForm(GecosForm):
             logger.debug("forms.py ::: CookbookUpload - cookbook_ver = %s" % cookbook_ver)
             cookbook_path = uploadir + cookbook_name
             logger.debug("forms.py ::: CookbookUpload - cookbook_path = %s" % cookbook_path)
-            os.rename(tmpdir, cookbook_path)
+            shutil.move(tmpdir, cookbook_path)
 
         except urllib2.HTTPError as e:
                 error = True


### PR DESCRIPTION
This code line produces an error: Invalid cross-device link.

os.rename(tmpdir, cookbook_path)

From python documentation (https://docs.python.org/2/library/os.html)
"Rename the file or directory src to dst. If dst is a directory, OSError will be raised. On Unix, if dst exists and is a file, it will be replaced silently if the user has permission. **The operation may fail on some Unix flavors if src and dst are on different filesystems**. If successful, the renaming will be an atomic operation (this is a POSIX requirement). On Windows, if dst already exists, OSError will be raised even if it is a file; there may be no way to implement an atomic rename when dst names an existing file"

Replace the line of code with this one:

shutil.move(tmpdir, cookbook_path)