### PR TITLE
Fix bad https redirections in Nginx

### DIFF
--- a/gecoscc/socks.py
+++ b/gecoscc/socks.py
@@ -115,9 +115,9 @@ class GecosWSGIHandler(GunicornWSGIHandler):
 
     def get_environ(self):
         env = super(GecosWSGIHandler, self).get_environ()
-        for key, value in self._headers():
-            if key  == 'HTTP_X_FORWARDED_PROTO' and 'https' == value:
-                env['wsgi.url_scheme'] = 'https'
+        headers = dict(self._headers())
+        if ('HTTP_X_FORWARDED_PROTO' in headers and headers['HTTP_X_FORWARDED_PROTO'] == 'https' ):
+            env['wsgi.url_scheme'] = 'https'
         return env
 
 class GecosSocketIOServer(SocketIOServer):

--- a/gecoscc/socks.py
+++ b/gecoscc/socks.py
@@ -19,7 +19,7 @@ from pyramid.threadlocal import get_current_registry
 from socketio import socketio_manage
 from socketio.namespace import BaseNamespace
 from socketio.server import SocketIOServer
-from socketio.sgunicorn import GeventSocketIOWorker
+from socketio.sgunicorn import GeventSocketIOWorker, GunicornWSGIHandler
 from socketio.virtsocket import Socket
 
 CHANNEL_WEBSOCKET = 'message'
@@ -111,6 +111,15 @@ def delete_computer(object_id, path):
     }))
 
 
+class GecosWSGIHandler(GunicornWSGIHandler):
+
+    def get_environ(self):
+        env = super(GecosWSGIHandler, self).get_environ()
+        for key, value in self._headers():
+            if key  == 'HTTP_X_FORWARDED_PROTO' and 'https' == value:
+                env['wsgi.url_scheme'] = 'https'
+        return env
+
 class GecosSocketIOServer(SocketIOServer):
 
     def get_socket(self, sessid=''):
@@ -129,6 +138,7 @@ class GecosSocketIOServer(SocketIOServer):
 class GecosGeventSocketIOWorker(GeventSocketIOWorker):
 
     server_class = GecosSocketIOServer
+    wsgi_handler = GecosWSGIHandler
 
 
 class GecosNamespace(BaseNamespace):


### PR DESCRIPTION
Gevent doesn't change from `http` to `https` protocol and, in case you configure NGINX to use only secure server, you'll get frontpage without styles sheets.

This PR makes `gevent` to use the enviroment variables to know if the protocol is `http` or `https`.