### PR TITLE
Bugfix: doble deletion of node

### DIFF
--- a/gecoscc/api/register_computer.py
+++ b/gecoscc/api/register_computer.py
@@ -15,12 +15,12 @@ from cornice.resource import resource
 
 from pyramid.threadlocal import get_current_registry
 
-from gecoscc.tasks import object_detached
 from gecoscc.api import BaseAPI
 from gecoscc.models import Node as MongoNode
 from gecoscc.permissions import http_basic_login_required
 from gecoscc.utils import get_chef_api, register_node, apply_policies_to_computer
 from gecoscc.socks import delete_computer, update_tree, invalidate_change, invalidate_delete 
+from gecoscc.eventsmanager import JobStorage
 
 
 @resource(path='/register/computer/',
@@ -81,7 +81,17 @@ class RegisterComputerResource(BaseAPI):
         node_deleted = self.collection.remove({'node_chef_id': node_id, 'type': 'computer'})
         num_node_deleted = node_deleted['n']
         if num_node_deleted >= 1:
-            object_detached.delay(self.request.user, 'computer', computer)
+            # Create a job so the administrator can see the 'detached' action
+            job_storage = JobStorage(self.request.db.jobs, self.request.user)
+            job_storage.create(obj=computer,
+                            op='detached',
+                            status='finished',
+                            message=self._("Pending: %d") %(0),
+                            policy={'name':'detached computer',
+                                    'name_es':self._('detached') + " " + self._('computer')},
+                            administrator_username=self.request.user['username'])
+        
+
             invalidate_delete(self.request, computer)
             if num_node_deleted == 1:
                 delete_computer(computer['_id'], computer['path'])

--- a/gecoscc/tasks.py
+++ b/gecoscc/tasks.py
@@ -1250,8 +1250,6 @@ class ChefTask(Task):
             2 - object type is emitter: printer, storage or repository
         '''
         updated = False
-        if action == 'detached':
-            return(node, False)
         if action not in ['changed', 'created', 'deleted', 'recalculate policies']:
             raise ValueError('The action should be changed, created, deleted or recalculate policies')
         
@@ -1607,12 +1605,6 @@ class ChefTask(Task):
         object_changed = getattr(self, '%s_changed' % obj['type'])
         object_changed(user, obj_without_policies, obj, action='deleted', computers=computers)
 
-    def object_detached(self, user, obj, computers=None):
-        obj_without_policies = deepcopy(obj)
-        obj_without_policies['policies'] = {}
-        object_changed = getattr(self, '%s_changed' % obj['type'])
-        object_changed(user, obj_without_policies, obj, action='detached', computers=computers)
-        
     def object_moved(self, user, objnew, objold):
         api = get_chef_api(self.app.conf, user)
         try:
@@ -1900,18 +1892,6 @@ class ChefTask(Task):
             self.disassociate_object_from_group(obj)
         self.log_action('deleted', 'Computer', obj)
 
-    def computer_detached(self, user, obj, computers=None):
-        self.object_detached(user, obj, computers=computers)
-        node_chef_id = obj.get('node_chef_id', None)
-        if node_chef_id:
-            api = get_chef_api(self.app.conf, user)
-            node = Node(node_chef_id, api)
-            node.delete()
-            client = Client(node_chef_id, api=api)
-            client.delete()
-
-        self.log_action('detached', 'Computer', obj)
-        
     def ou_created(self, user, objnew, computers=None):
         self.object_created(user, objnew, computers=computers)
         self.log_action('created', 'OU', objnew)
@@ -2085,21 +2065,6 @@ def object_deleted(user, objtype, obj, computers=None):
     else:
         self.log('error', 'The method {0}_deleted does not exist'.format(
             objtype))
-
-@task(base=ChefTask)
-def object_detached(user, objtype, obj, computers=None):
-    self = object_detached
-    func = getattr(self, '{0}_detached'.format(objtype), None)
-    if func is not None:
-        try:
-            return func(user, obj, computers=computers)
-        except Exception as e:
-            self.report_unknown_error(e, user, obj, 'deleted')
-            invalidate_jobs(self.request, user)
-    else:
-        self.log('error', 'The method {0}_detached does not exist'.format(
-            objtype))
-
 
 @task(base=ChefTask)
 def chef_status_sync(node_id, auth_user):


### PR DESCRIPTION
Fix a bug that happened when "object_detached" tried to remove a Chef node that was already deleted by /register/node