### PR TITLE
Knife EC plugin with webui-key option

### DIFF
--- a/gecoscc/scripts/chef_backup.sh
+++ b/gecoscc/scripts/chef_backup.sh
@@ -13,14 +13,12 @@
 KNIFE_BIN=/opt/opscode/bin/knife
 
 # Checking number of arguments
-[[ $# -ne  4 ]] && echo "Illegal number of parameters" && exit 1
+[[ $# -ne 2 ]] && echo "Illegal number of parameters" && exit 1
 
 # knife-ec-backup plugin execution
 # Params:
 #   -s, --server-url URL             Chef Server URL
-#   -u, --user USER                  API Client Username
-#   -k, --key KEY                    API Client Key
 #   --webui-key			     Used to set the path to the WebUI Key. If your chef server is in a different machine,
 #                                    please, copy /etc/opscode/webui_priv.pem to this server and point this path to the file
 
-$KNIFE_BIN ec backup $1 -y -s $2 -u $3 -k $4 --webui-key /etc/opscode/webui_priv.pem
+$KNIFE_BIN ec backup $1 -y -s $2 --webui-key /etc/opscode/webui_priv.pem

--- a/gecoscc/scripts/chef_backup.sh
+++ b/gecoscc/scripts/chef_backup.sh
@@ -20,5 +20,7 @@ KNIFE_BIN=/opt/opscode/bin/knife
 #   -s, --server-url URL             Chef Server URL
 #   -u, --user USER                  API Client Username
 #   -k, --key KEY                    API Client Key
+#   --webui-key			     Used to set the path to the WebUI Key. If your chef server is in a different machine,
+#                                    please, copy /etc/opscode/webui_priv.pem to this server and point this path to the file
 
-$KNIFE_BIN ec backup $1 -y -s $2 -u $3 -k $4
+$KNIFE_BIN ec backup $1 -y -s $2 -u $3 -k $4 --webui-key /etc/opscode/webui_priv.pem

--- a/gecoscc/scripts/chef_restore.sh
+++ b/gecoscc/scripts/chef_restore.sh
@@ -20,5 +20,7 @@ KNIFE_BIN=/opt/opscode/bin/knife
 #   -s, --server-url URL             Chef Server URL
 #   -u, --user USER                  API Client Username
 #   -k, --key KEY                    API Client Key
+#   --webui-key                      Used to set the path to the WebUI Key. If your chef server is in a different machine,
+#                                    please, copy /etc/opscode/webui_priv.pem to this server and point this path to the file
 
-$KNIFE_BIN ec restore $1 -y -s $2 -u $3 -k $4
+$KNIFE_BIN ec restore $1 -y -s $2 -u $3 -k $4 --webui-key /etc/opscode/webui_priv.pem

--- a/gecoscc/scripts/chef_restore.sh
+++ b/gecoscc/scripts/chef_restore.sh
@@ -13,14 +13,12 @@
 KNIFE_BIN=/opt/opscode/bin/knife
 
 # Checking number of arguments
-[[ $# -ne  4 ]] && echo "Illegal number of parameters" && exit 1
+[[ $# -ne 2 ]] && echo "Illegal number of parameters" && exit 1
 
 # knife-ec-backup plugin execution
 # Params:
 #   -s, --server-url URL             Chef Server URL
-#   -u, --user USER                  API Client Username
-#   -k, --key KEY                    API Client Key
 #   --webui-key                      Used to set the path to the WebUI Key. If your chef server is in a different machine,
 #                                    please, copy /etc/opscode/webui_priv.pem to this server and point this path to the file
 
-$KNIFE_BIN ec restore $1 -y -s $2 -u $3 -k $4 --webui-key /etc/opscode/webui_priv.pem
+$KNIFE_BIN ec restore $1 -y -s $2 --webui-key /etc/opscode/webui_priv.pem

--- a/gecoscc/utils.py
+++ b/gecoscc/utils.py
@@ -2466,7 +2466,7 @@ def upload_cookbook(user=None,cookbook_path=None):
     return exitstatus
 
 
-def chefserver_backup(username=None, backupdir=None):
+def chefserver_backup(backupdir=None):
     ''' Backing up all Chef server data
     
     Args:
@@ -2482,21 +2482,16 @@ def chefserver_backup(username=None, backupdir=None):
 
         if is_cli_request():
             has_cli_permission(os.environ['SCRIPT_CODE'], chefserver_backup.__name__)
-            username = os.environ['GECOS_USER']
             backupdir = os.environ['BACKUP_DIR']
 
-        logger.debug("utils.py ::: chefserver_backup - username = %s" % username)
         logger.debug("utils.py ::: chefserver_backup - backupdir = %s" % backupdir)
 
-        assert username is not None or backupdir is not None, _('Missing required arguments')
+        assert backupdir is not None, _('Missing required arguments')
 
         if not os.path.exists(backupdir):
             os.mkdir(backupdir)
 
-        admin_cert = os.sep.join([settings.get('firstboot_api.media'), username, 'chef_user.pem'])
-        logger.debug("utils.py ::: chefserver_backup - admin_cert = %s" % admin_cert)
-
-        command = '{0} {1} {2} {3} {4}'.format(settings['updates.chef_backup'], backupdir, settings.get('chef.url'), username, admin_cert)
+        command = '{0} {1} {2}'.format(settings['updates.chef_backup'], backupdir, settings.get('chef.url'))
         backup_output = subprocess.check_output(command, shell=True)
         logger.info(backup_output)
         logger.info("Chef Server backup ended.")
@@ -2512,7 +2507,7 @@ def chefserver_backup(username=None, backupdir=None):
 
     return exitstatus
 
-def chefserver_restore(username=None, backupdir=None):
+def chefserver_restore(backupdir=None):
     ''' Restoring Chef server data from a backup that was created by the chefserver_backup function
     
     Args:
@@ -2528,21 +2523,16 @@ def chefserver_restore(username=None, backupdir=None):
 
         if is_cli_request():
             has_cli_permission(os.environ['SCRIPT_CODE'], chefserver_restore.__name__)
-            username = os.environ['GECOS_USER']
             backupdir = os.environ['BACKUP_DIR']
 
-        logger.debug("utils.py ::: chefserver_backup - username = %s" % username)
         logger.debug("utils.py ::: chefserver_backup - backupdir = %s" % backupdir)
 
-        assert username is not None or backupdir is not None, _('Missing required arguments')
+        assert backupdir is not None, _('Missing required arguments')
 
         if not os.path.exists(backupdir):
             os.mkdir(backupdir)
 
-        admin_cert = os.sep.join([settings.get('firstboot_api.media'), username, 'chef_user.pem'])
-        logger.debug("utils.py ::: chefserver_backup - admin_cert = %s" % admin_cert)
-
-        command = '{0} {1} {2} {3} {4}'.format(settings['updates.chef_restore'], backupdir, settings.get('chef.url'), username, admin_cert)
+        command = '{0} {1} {2}'.format(settings['updates.chef_restore'], backupdir, settings.get('chef.url'))
         restore_output = subprocess.check_output(command, shell=True)
         logger.info(restore_output)
         logger.info("Chef Server restore ended.")


### PR DESCRIPTION
Overrides default behaviour of plugin with webui-key option. 
Useful in case of chef server is in a different machine of Gecos Control Center