### PR TITLE
Adding debug_mode flag to computer api

### DIFF
--- a/gecoscc/api/computers.py
+++ b/gecoscc/api/computers.py
@@ -33,6 +33,7 @@ import re
 import logging
 logger = logging.getLogger(__name__)
 
+DEBUG_MODE_ENABLE_ATTR_PATH = 'gecos_ws_mgmt.single_node.debug_mode_res.enable_debug'
 
 @resource(collection_path='/api/computers/',
           path='/api/computers/{oid}/',
@@ -95,6 +96,12 @@ class ComputerResource(TreeLeafResourcePaginated):
             cpu = ohai.get('cpu', {}).get('0', {})
             dmi = ohai.get('dmi', {})
             
+            # debug_mode flag for logs tab
+            debug_mode = False
+            try:
+                debug_mode = computer_node.attributes.get_dotted(DEBUG_MODE_ENABLE_ATTR_PATH)
+            except KeyError:
+                pass
             
             # Get logs info
             logs_data = node_collection.find_one({"type": "computer", "_id": ObjectId(nodeid)}, {"logs": True})
@@ -128,6 +135,7 @@ class ComputerResource(TreeLeafResourcePaginated):
                            'lsb': ohai.get('lsb', {}),
                            'kernel': ohai.get('kernel', {}),
                            'filesystem': ohai.get('filesystem', {}),
+                           'debug_mode': debug_mode,
                            'logs': logs
                            })
         except (urllib2.URLError, ChefError, ChefServerError):

--- a/gecoscc/templates/bb-computer.html
+++ b/gecoscc/templates/bb-computer.html
@@ -344,11 +344,12 @@
                     <div class="text-muted bootstrap-admin-box-title">{{ gettext('Logs') }}</div>
                 </div>
                 
-                <% if (logs && logs.files && logs.files.length > 0) { %>
+                <% if (debug_mode) { %>
                 <div class="bootstrap-admin-panel-content">
                     <div class="row"><div class="col-sm-12"><strong>{{ gettext('Date') }}:</strong> <%= logs.date %></div></div>
                     <div class="row"><div class="col-sm-12"></div></div>
                     <div class="object_related_list">
+                        <% if (logs && logs.files && logs.files.length > 0) { %>
                         <table class="table table-bordered">
                         <tr>
                          <th>{{ gettext('File') }}</th>
@@ -385,12 +386,14 @@
                                     
                         <% }) %>
                         </table>
+                        <% } else { %>
+                            <div class="alert alert-warning">{{ gettext('There are no logs for this computer at this moment.') }}</div>
+                        <% } %>
                     </div>    
                     </div>
                 </div>
                 <% } else { %>
                 <div class="bootstrap-admin-panel-content">
-                    <div class="alert alert-warning">{{ gettext('There are no logs for this computer at this moment.') }}</div>
                     <div class="alert alert-info">
                         <h3>{{ gettext('Please enable the debug mode for this computer') }}</h3>
                         <p>


### PR DESCRIPTION
- Do not wait for the logs of the execution of the chef-client so that the view logs knows that the debug mode is activated