### PR TITLE
Fix forbidden page visualization.

### DIFF
--- a/gecoscc/filters.py
+++ b/gecoscc/filters.py
@@ -24,7 +24,13 @@ def admin_serialize(admin):
         'ou_managed': admin.get('ou_managed', []),
         'ou_remote': admin.get('ou_remote', [])
     })
-    return json.dumps(serialized)
+    json_data = ''
+    try:
+        json_data = json.dumps(serialized)
+    except TypeError, e:
+        json_data = 'Error serializing user: %s' % (str(e))
+    
+    return json_data
 
 def datetime(value, date_format='medium'):
     '''

--- a/gecoscc/templates/base_navbar.jinja2
+++ b/gecoscc/templates/base_navbar.jinja2
@@ -22,9 +22,9 @@
                         <a href="{{ help_base_url }}" target="_blank">{{ gettext('Help') }}</a>
                     </li>
 
-                    {% if (request.user.get('is_superuser') or
+                    {% if (request.user and (request.user.get('is_superuser') or
                            request.user.get('ou_managed', []) or
-                           request.user.get('ou_readonly', [])
+                           request.user.get('ou_readonly', []))
                        ):
                     %}
 
@@ -74,6 +74,7 @@
 
                     {% endif %}
 
+                    {% if (request.user): %}
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-hover="dropdown">{{ request.user['username'] }} <b class="caret"></b></a>
                         <ul class="dropdown-menu">
@@ -95,6 +96,7 @@
                             </li>
                         </ul>
                     </li>
+                    {% endif %}
                 </ul>
             </div><!-- /.navbar-collapse -->
         </div>


### PR DESCRIPTION
If you stop using the GECOS CC for a long time and your session expires, when you use any functionality that uses AJAX there is an error in the server due to the non existence of the user session data.

This can be tested with CURL:
` curl -X GET -H "Content-type: application/json" -H "Accept: application/json"  "http://<SERVER>/api/nodes/?iname=depar&search_by=nodename&type=&page=1&pagesize=10&_=1572002868893"`

This patch checks that user is not None in the JINJA template and checks that the user can be JSON serialized.