### PR TITLE
Fix a bug in the nodes tree that appeared after searching twice.

### DIFF
--- a/gecoscc/static/js/app.js
+++ b/gecoscc/static/js/app.js
@@ -770,10 +770,15 @@ var App;
                     throw "Search require a 'search filter' attribute";
                 }
 
+                var lastTreeView = App.tree.currentView;
+                if (!_.isUndefined(App.tree.currentView.treeView)) {
+                    lastTreeView = App.tree.currentView.treeView;
+                }
+
                 var data = new App.Tree.Models.Search({ keyword: keyword, search_by: dparameters['searchby'], search_filter: dparameters['searchfilter']}),
                     view = new App.Tree.Views.SearchResults({
                         collection: data,
-                        treeView: App.tree.currentView
+                        treeView: lastTreeView
                     });
 
                 data.goTo(1, {


### PR DESCRIPTION
This bug appeared when you search for something, for example "ESPA", and that search returns two many nodes in the tree. So you search again for example "informacionESPA", and when you select that node you can see that in the nodes tree instead of loading the "informacionESPA" node location is loaded the previous search results.

This patch fixes that bug.