### PR TITLE
Fix "gecos_path_names" and "gecos_path_ids" information in Chef Node.

### DIFF
--- a/gecoscc/tasks.py
+++ b/gecoscc/tasks.py
@@ -1722,6 +1722,8 @@ class ChefTask(Task):
 
             # Updates path to Chef node after copying & pasting (computer)
             if objnew['type'] == 'computer':
+                # TODO: change these "reserve" and "release" node functions
+                # when the #248 pull request gets approved. 
                 node = reserve_node_or_raise(objnew['node_chef_id'], api,
                     'gcc-tasks-%s-%s' % (objnew['_id'], random.random()), 10)
                 add_path_attrs_to_node(node, objnew['path'], self.db.nodes,

--- a/gecoscc/tasks.py
+++ b/gecoscc/tasks.py
@@ -1722,7 +1722,12 @@ class ChefTask(Task):
 
             # Updates path to Chef node after copying & pasting (computer)
             if objnew['type'] == 'computer':
-                add_path_attrs_to_node(api, objnew['node_chef_id'], objnew['path'], self.db.nodes)
+                node = reserve_node_or_raise(objnew['node_chef_id'], api,
+                    'gcc-tasks-%s-%s' % (objnew['_id'], random.random()), 10)
+                add_path_attrs_to_node(node, objnew['path'], self.db.nodes,
+                                       False)
+                save_node_and_free(node)
+                
 
         except KeyError:
             self.log('error', "object_moved - 'apply_policies_to_%s' not implemented!"%(objnew['type']))

--- a/gecoscc/utils.py
+++ b/gecoscc/utils.py
@@ -890,11 +890,13 @@ def add_path_attrs_to_node(node, strpath, collection, save=True):
         str(node)))
     logger.debug("utils ::: add_path_chef_node - strpath = {}".format(strpath))
 
-    nodeids = map(ObjectId, strpath.split(',')[1:])
-    logger.debug("utils ::: add_path_chef_node - nodeids = {}".format(nodeids))
+    pathnames = 'root'
+    for elm in strpath.split(','):
+        if elm == 'root':
+            continue
+        ou = collection.find_one({'_id': ObjectId(elm)})
+        pathnames += ',' + ou['name'] 
 
-    pathnames = 'root,' + ','.join([n['name'] for n in collection.find(
-        {'_id': {'$in': nodeids}})])
     logger.debug("utils ::: add_path_chef_node - pathnames = {}".format(
         pathnames))
 

--- a/gecoscc/utils.py
+++ b/gecoscc/utils.py
@@ -892,8 +892,10 @@ def add_path_attrs_to_node(api, node_id, strpath, collection):
     nodeids = map(ObjectId, strpath.split(',')[1:])
     logger.debug("utils ::: add_path_chef_node - nodeids = {}".format(nodeids))
 
-    pathnames = 'root,' + ','.join([n['name'] for n in collection.find({'_id': {'$in': nodeids}})])
-    logger.debug("utils ::: add_path_chef_node - pathnames = {}".format(pathnames))
+    pathnames = 'root,' + ','.join([n['name'] for n in collection.find(
+        {'_id': {'$in': nodeids}})])
+    logger.debug("utils ::: add_path_chef_node - pathnames = {}".format(
+        pathnames))
 
     try:
         node = ChefNode(node_id, api)
@@ -901,7 +903,8 @@ def add_path_attrs_to_node(api, node_id, strpath, collection):
         node.attributes.set_dotted('gecos_path_names', pathnames)
         node.save()
     except (TypeError, KeyError, ChefError) as e:
-        logger.error("utils ::: add_path_chef_node - Exception to setting up path in chef node: {}".format(e))
+        logger.error("utils ::: add_path_chef_node - Exception to setting up"\
+                     " path in chef node: {}".format(e))
         raise setPathAttrsToNodeException
 
 def register_node(api, node_id, ou, collection_nodes):

--- a/gecoscc/utils.py
+++ b/gecoscc/utils.py
@@ -883,10 +883,11 @@ def get_cookbook(api, cookbook_name):
 class setPathAttrsToNodeException(Exception):
     pass
 
-def add_path_attrs_to_node(api, node_id, strpath, collection):
+def add_path_attrs_to_node(node, strpath, collection, save=True):
     ''' Setting up gecos_path_ids, gecos_path_names attributes to Chef node '''
 
-    logger.debug("utils ::: add_path_chef_node - node_id = {}".format(node_id))
+    logger.debug("utils ::: add_path_chef_node - node_id = {}".format(
+        str(node)))
     logger.debug("utils ::: add_path_chef_node - strpath = {}".format(strpath))
 
     nodeids = map(ObjectId, strpath.split(',')[1:])
@@ -898,10 +899,10 @@ def add_path_attrs_to_node(api, node_id, strpath, collection):
         pathnames))
 
     try:
-        node = ChefNode(node_id, api)
         node.attributes.set_dotted('gecos_path_ids', strpath)
         node.attributes.set_dotted('gecos_path_names', pathnames)
-        node.save()
+        if save:
+            node.save()
     except (TypeError, KeyError, ChefError) as e:
         logger.error("utils ::: add_path_chef_node - Exception to setting up"\
                      " path in chef node: {}".format(e))
@@ -921,7 +922,7 @@ def register_node(api, node_id, ou, collection_nodes):
 
         try:
             nodepath = '{},{}'.format(ou['path'], unicode(ou['_id']))
-            add_path_attrs_to_node(api, node_id, nodepath, collection_nodes)
+            add_path_attrs_to_node(node, nodepath, collection_nodes)
 
             comp_model = Computer()
             computer = comp_model.serialize({'path': nodepath,
@@ -958,7 +959,7 @@ def update_node(api, node_id, ou, collection_nodes):
 
         try:
             nodepath = '{},{}'.format(ou['path'], unicode(ou['_id']))
-            add_path_attrs_to_node(api, node_id, nodepath, collection_nodes)
+            add_path_attrs_to_node(node, nodepath, collection_nodes)
 
             comp_model = Computer()
             computer = comp_model.serialize({'path': nodepath,


### PR DESCRIPTION
Changes to check "gecos_path_ids" and "gecos_path_names" fields in "check_node_policies" script, lock the Chef nodes before adding/modifying "gecos_path_ids" and "gecos_path_names" fields, and fix  "gecos_path_names" field calculation.